### PR TITLE
ユーザー編集機能

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,21 @@
 class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_account_update_params, only: [:update]
   before_action :ensure_normal_user, only: %i[update destroy]
-
+  
   def ensure_normal_user
     redirect_to root_path, alert: 'ゲストユーザーは削除・更新できません。' if resource.email == 'guest@example.com'
+  end
+
+  protected
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+
+  def after_update_path_for(_resource)
+    rooads_path
+  end
+
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [:nickname, :area_id, :gender_id, :profile, :image])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,21 @@
 class UsersController < ApplicationController
+  def update
+    @user = User.find(params[:id])
+    if @user.valid?
+      @user.update(update_params)
+      redirect_to user_path(@user.id)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def user_params
     params.require(:user).permit(:nickname, :gender_id, :profile, :image, :area_id, :email, :password, :password_confirmation)
+  end
+
+  def update_params
+    params.require(:user).permit(:nickname, :gender_id, :profile, :image, :area_id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,11 +5,12 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   with_options presence: true do
     validates :nickname
-    validates :password
+    validates :password, on: :create
   end
+  
 
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,100}+\z/i.freeze
-  validates :password, format: { with: VALID_PASSWORD_REGEX }
+  validates :password, format: { with: VALID_PASSWORD_REGEX }, allow_blank: true
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :gender
@@ -27,5 +28,18 @@ class User < ApplicationRecord
 
   def liked_by?(rooad_id)
     likes.where(rooad_id: rooad_id).exists?
+  end
+
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+
+    if params[:password].blank? && params[:password_confirmation].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation)
+    end
+
+    result = update_attributes(params, *options)
+    clean_up_passwords
+    result
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,35 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+<h2>ユーザー編集</h2>
+<%= form_with model: @user, url: user_registration_path, class: 'registration-main', local: true do |f| %> 
   <%= render "devise/shared/error_messages", resource: resource %>
-
+<div class="field">
+    <%= f.label :nickname %><br />
+     <%= f.text_field :nickname,  placeholder:"例) ゲスト", maxlength:"12" %>
+  </div>
+ 
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :profile %><br />
+     <%= f.text_area :profile,  placeholder:"例) エンジニア歴1年です！", maxlength:"200" %>
   </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
+<div class="field">
+    <%= f.label "性別" %><br />
+   <%= f.collection_select(:gender_id, Gender.all, :id, :name, {}, {class:"gender-select"}) %>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+<div class="field">
+    <%= f.label "年齢" %><br />
+   <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"gender-select"}) %>
   </div>
 
   <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
+   <%= f.label  "写真" %><br />
+   <div id="image-list"></div>
+    
+    <%= f.file_field :image %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "更新" %>
   </div>
+  
 <% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -23,8 +23,13 @@
 
   <div class="field">
    <%= f.label  "写真" %><br />
-   <div id="image-list"></div>
     
+  <% if @user.image.present? %> 
+   <%= link_to image_tag(@user.image ), root_path %>
+  <% else %> 
+   <%= image_tag 'gesuto.png' %>
+  <% end %>
+    <div id="image-list"></div>
     <%= f.file_field :image %>
   </div>
 

--- a/app/views/rooads/index.html.erb
+++ b/app/views/rooads/index.html.erb
@@ -1,6 +1,7 @@
 <% breadcrumb :rooads %>
 <%= link_to 'イベント投稿',  new_rooad_path %>
 <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %> 
+<%= link_to 'ユーザー編集', edit_user_registration_path %> 
 
 <h1>口コミ一覧</h1>
 

--- a/app/views/rooads/show.html.erb
+++ b/app/views/rooads/show.html.erb
@@ -31,9 +31,6 @@
 <%# フォーム(repetitions)繰り返し %>
  <h2>学習詳細</h2>
 <%  @rooad.repetitions.each do |rooad|%>
-
-
-
   <p>学習内容: <%=  rooad.name %></p>
   <p>学習期間: <%=  rooad.period %>日</p>
  <% if rooad.memo.present? %> 

--- a/app/views/rooads/show.html.erb
+++ b/app/views/rooads/show.html.erb
@@ -1,5 +1,10 @@
   <% breadcrumb :show %>
   <%# <p>/写真</p> %>
+  <% if @rooad.user.image.present? %> 
+  <%= link_to image_tag(@rooad.user.image, class: "card__img" ), root_path %>
+ <% else %> 
+  <%= image_tag 'gesuto.png', class: "card__img" %>
+ <% end %>
  <p>名前: <%=  @rooad.user.nickname %>さん</p> 
  <p>学習状態：<%= @rooad.status.name %></p>
  <p>タイトル:<%= @rooad.title %></p>


### PR DESCRIPTION
## 概要
- パスワードとemailなしのユーザー編集機能を実装しました。
- 編集ページで前回のアイコン画像が表示できるようにしました。
- ロードマップの詳細でもアイコン画像が表示できるようになりました。

## 参考記事
https://kyoro1210.hatenablog.com/entry/2020/10/23/094309
 